### PR TITLE
Umstellung auf 'includeCurrentPageSubPath'

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -15,3 +15,6 @@ page:
         categories: { title: translate:page_categories }
         settings: { title: translate:page_settings }
         info: { title: translate:page_info }
+
+requires:
+    redaxo: '>=5.1.0'

--- a/package.yml
+++ b/package.yml
@@ -15,6 +15,3 @@ page:
         categories: { title: translate:page_categories }
         settings: { title: translate:page_settings }
         info: { title: translate:page_info }
-
-requires:
-    redaxo: '>=5.1.0'

--- a/pages/index.php
+++ b/pages/index.php
@@ -5,4 +5,4 @@
 
 echo rex_view::title($this->i18n($this->getName()));
 
-include rex_be_controller::getCurrentPageObject()->getSubPath();
+rex_be_controller::includeCurrentPageSubPath();


### PR DESCRIPTION
Ziel des PR: Umstellung auf aktuelle rex-Methoden und einheitliche Vorgehensweise
in möglichst allen AddOns.

Wie ich letztens gelernt habe, gibt es eine alte und eine aktuelle Methode, die 
Sub-Pages einzubinden. Die neue Methode ist seit REDAXO 5.1 verfügbar. 

Die alte Methode funktioniert weiterhin, sollte aber wegen verbesserter Interoperabilität
zwischen AddOns auf die neue Version umgestellt werden (Hinweis von gharlan).
In den Core-Addons ist das bereits geschehen, desgleichen bei einige FOR- und Y-Addons.
Bezogen auf das Addon selbst sind beide Varianten derzeit gleichwertig. Die neue Methode
erlaubt z.B. eine verbesserte Einbindung von Pages aus anderen Addons, die dann im 
Context des Quell-Addons laufen und nicht des Ziel-Addons.

Betroffen sind rund 40 AddOns (FOR/Y), konkret deren Script **pages/index.php**, das
wie folgt geändert werden sollte:

Alt:
```
    echo rex_view::title(.....);
    include rex_be_controller::getCurrentPageObject()->getSubPath();
```
ab REDAXO 5.1:
```
    echo rex_view::title(.....);
    rex_be_controller::includeCurrentPageSubPath();
```
