### PR TITLE
Metainfos verschieben bei REDAXO ab 5.10.0-dev deaktivieren

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,9 +1,6 @@
 /**
  * Move metainfo
  */
-.rex-main-sidebar > section:first-child {
-    display: none;
-}
 .moved-metainfo .rex-form-group:not(.rex-form-group-vertical) > dt,
 .moved-metainfo .rex-form-group:not(.rex-form-group-vertical) > dd,
 .moved-metainfo .rex-form-group:not(.rex-form-group-vertical) > dd:first-child,

--- a/boot.php
+++ b/boot.php
@@ -22,6 +22,10 @@ if (rex::isBackend() && rex::getUser() && !rex::isSetup()) {
     structure_tweaks_category_splitter::init();
 
     if (rex_string::versionCompare(rex::getVersion(), '5.10.0-dev', '<')) {
+        // load settings page
+        $page = $this->getProperty('page');
+        $page['subpages']['settings'] = ['title' => $this->i18n('structure_tweaks_page_settings')];
+        $this->setProperty('page', $page);
         // Move meta infos
         if ($this->getConfig('move_meta_info_page')) {
             structure_tweaks_move_metainfo::init();

--- a/boot.php
+++ b/boot.php
@@ -21,8 +21,10 @@ if (rex::isBackend() && rex::getUser() && !rex::isSetup()) {
     // Split categories
     structure_tweaks_category_splitter::init();
 
-    // Move meta infos
-    if ($this->getConfig('move_meta_info_page')) {
-        structure_tweaks_move_metainfo::init();
-    }
+    if (rex_string::versionCompare(rex::getVersion(), '5.10.0-dev', '<')) {
+        // Move meta infos
+        if ($this->getConfig('move_meta_info_page')) {
+            structure_tweaks_move_metainfo::init();
+        }
+     }
 }

--- a/package.yml
+++ b/package.yml
@@ -1,7 +1,7 @@
 package: structure_tweaks
 version: '1.2.0'
 author: Friends Of REDAXO
-supportpage: https://github.com/FriendsOfREDAXO
+supportpage: https://github.com/FriendsOfREDAXO/structure_tweaks
 
 requires:
     redaxo: '^5.2.0'

--- a/package.yml
+++ b/package.yml
@@ -1,7 +1,7 @@
 package: structure_tweaks
-version: '1.1.1'
+version: '1.2.0'
 author: Friends Of REDAXO
-supportpage: https://github.com/FriendsOfREDAXO/structure_tweaks
+supportpage: https://github.com/FriendsOfREDAXO
 
 requires:
     redaxo: '^5.2.0'
@@ -13,5 +13,8 @@ page:
     perm: admin
     subpages:
         categories: { title: translate:page_categories }
-        settings: { title: translate:page_settings }
-        info: { title: translate:page_info }
+        info: 
+          title: translate:page_info
+          itemclass: pull-right 
+
+


### PR DESCRIPTION
Metainfos verschieben bei REDAXO ab 5.10.0-dev deaktivieren