### PR TITLE
Anpassungen für Dark-Mode ab REDAXO 5.13

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -47,3 +47,14 @@
     background-color: #F3F6FB !important;
     border-color: #F3F6FB !important;;
 }
+@media (prefers-color-scheme: dark) {
+    body.rex-has-theme:not(.rex-theme-light) .structure-tweaks-splitter,
+    body.rex-has-theme:not(.rex-theme-light) .structure-tweaks-splitter:focus,
+    body.rex-has-theme:not(.rex-theme-light) .structure-tweaks-splitter:active,
+    body.rex-has-theme:not(.rex-theme-light) .structure-tweaks-splitter:hover {
+        color: rgba(255, 255, 255, 0.75);
+        font-weight: bold;
+        background-color: #1b232c !important;
+        border-color: #1b232c !important;;
+    }
+}

--- a/lib/pages/page_categories.php
+++ b/lib/pages/page_categories.php
@@ -111,6 +111,7 @@ class structure_tweaks_page_categories extends structure_tweaks_base
 
         $field = $form->addSelectField('type');
         $field->setLabel(self::msg('type'));
+        $field->setAttribute('class', 'form-control selectpicker');
         $select = $field->getSelect();
         $select->setSize(1);
         $select->addOption('---', '');


### PR DESCRIPTION
- Farben der Kategorie-Trenner für Dark-Mode angepasst
- Select auf Bootstrap Select umgestellt 